### PR TITLE
feat: add terminal close action, activity bar terminal button, and ed…

### DIFF
--- a/lib/editor_screen.dart
+++ b/lib/editor_screen.dart
@@ -673,6 +673,11 @@ class _EditorScreenState extends State<EditorScreen> {
                         height: _terminalHeight,
                         workingDirectory: _rootNode?.path,
                         initialCommand: _pendingCommand,
+                        onCloseTerminal: () {
+                          setState(() {
+                            _isOutputVisible = false;
+                          });
+                        },
                         onCommandExecuted: () {
                           setState(() {
                             _pendingCommand = null;
@@ -717,6 +722,16 @@ class _EditorScreenState extends State<EditorScreen> {
             );
           }),
           const Spacer(),
+          ActivityBarItem(
+            icon: Icons.terminal,
+            tooltip: 'Terminal',
+            isSelected: false,
+            onTap: () {
+              setState(() {
+                _isOutputVisible = !_isOutputVisible;
+              });
+            },
+          ),
         ],
       ),
     );
@@ -927,6 +942,12 @@ class _EditorScreenState extends State<EditorScreen> {
         }
       },
       child: MonacoEditor(
+        loadingBuilder: (context) => Container(
+          color: const Color(0xFF1E1E1E),
+          child: const Center(
+            child: CircularProgressIndicator(color: Color(0xFF42A5F5)),
+          ),
+        ),
         initialValue: _currentCode,
         options: const EditorOptions(
           language: MonacoLanguage.dart,

--- a/lib/output_panel.dart
+++ b/lib/output_panel.dart
@@ -11,6 +11,7 @@ class OutputPanel extends StatefulWidget {
   final String? workingDirectory;
   final String? initialCommand;
   final VoidCallback? onCommandExecuted;
+  final VoidCallback? onCloseTerminal;
 
   const OutputPanel({
     super.key,
@@ -19,6 +20,7 @@ class OutputPanel extends StatefulWidget {
     this.workingDirectory,
     this.initialCommand,
     this.onCommandExecuted,
+    this.onCloseTerminal,
   });
 
   @override
@@ -176,6 +178,14 @@ class _OutputPanelState extends State<OutputPanel> {
                   icon: Icons.delete_outline,
                   tooltip: 'Clear',
                   onPressed: () {
+                    pty?.write(Uint8List.fromList(utf8.encode("clear\n")));
+                  },
+                ),
+                _TerminalHeaderButton(
+                  icon: Icons.close,
+                  tooltip: 'Close Terminal',
+                  onPressed: () {
+                    widget.onCloseTerminal?.call();
                     pty?.write(Uint8List.fromList(utf8.encode("clear\n")));
                   },
                 ),


### PR DESCRIPTION
- Added a close button to the terminal window for quick dismissal
- Introduced a terminal shortcut button in the Activity Bar
- Updated the editor opening loader with a background color for better visual feedback

Screenshots and demo videos are attached to showcase the changes.

<img width="1440" height="900" alt="Screenshot 2025-12-26 at 20 43 46" src="https://github.com/user-attachments/assets/b5430076-66b6-47a4-a761-d2a8354effbf" />

<img width="1440" height="900" alt="Screenshot 2025-12-26 at 20 43 36" src="https://github.com/user-attachments/assets/01ef2fa7-59e7-40cd-a3e1-0b608aff7053" />

https://github.com/user-attachments/assets/c6f8f747-9d68-4c9b-8a02-4d1864c36961

https://github.com/user-attachments/assets/77df8ea3-4419-4854-ae0d-481a590d8291

